### PR TITLE
Updating access keys

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -20,130 +20,144 @@
                 <li id="siteaction-contact">
                     <a href="/site/contact-info" accesskey="9" title="Contact">Contact</a>
                 </li>
-            </ul><a id="portal-logo" accesskey="1" href="/site" name="portal-logo"><img src="/site/logo.jpg" alt="" title="" height="73" width="450" /></a>
+            </ul><a id="portal-logo" accesskey="1" href="/site" name="portal-logo"><img src="/site/logo.jpg" alt="" height="73" width="450" /></a>
             <div id="portal-globalnav">
                 <div class="csshover">
                     <ul>
+                        <!-- Access key hidden links -->
+                        <li style="display:none" class="plain">
+                            <a accesskey="4" href="/site/gsearch/">Search</a>
+                        </li>
+                        <li style="display:none" class="plain">
+                            <a accesskey="5" href="/site/support/faq">FAQ</a>
+                        </li>
+                        <li style="display:none" class="plain">
+                            <a accesskey="7" href="/site/products">Products</a>
+                        </li>
+                        <li style="display:none" class="plain">
+                            <a accesskey="8" href="/site/support">Documentation</a>
+                        </li>
+                        <!-- end -->
                         <li id="portaltab-index_html" class="plain">
-                            <a href="/site" accesskey="t" title="">Home</a>
+                            <a href="/site">Home</a>
                         </li>
                         <li id="portaltab-Products" class="plain">
-                            <a href="/site/products" accesskey="p" title="">Products</a>
+                            <a href="/site/products">Products</a>
                             <ul>
                                 <li>
-                                    <a href="/site/products/omero" accesskey="o" title="">OMERO</a>
+                                    <a href="/site/products/omero">OMERO</a>
                                 </li>
                                 <li>
-                                    <a href="/site/products/bio-formats" accesskey="b" title="">Bio-Formats</a>
+                                    <a href="/site/products/bio-formats">Bio-Formats</a>
                                 </li>
                                 <li>
-                                    <a href="/site/products/ome-tiff" accesskey="t" title="">OME-TIFF</a>
+                                    <a href="/site/products/ome-tiff">OME-TIFF</a>
                                 </li>
                                 <li>
-                                    <a href="/site/products/partner" accesskey="p" title="">Partner Projects</a>
+                                    <a href="/site/products/partner">Partner Projects</a>
                             </li>
                             <li>
-                                <a href="/site/products/ome5" accesskey="5" title="">OME 5</a>
+                                <a href="/site/products/ome5">OME 5</a>
                             </li>
                             <li>
-                                    <a href="/site/products/legacy" accesskey="l" title="">Legacy</a>
+                                    <a href="/site/products/legacy">Legacy</a>
                                 </li>
                             </ul>
                         </li>
                         <li id="portaltab-support" class="plain">
-                            <a href="/site/support" accesskey="s" title="">Documentation</a>
+                            <a href="/site/support">Documentation</a>
                             <ul>
                                 <li>
-                                    <a href="/site/support/omero4" accesskey="o" title="">OMERO</a>
+                                    <a href="/site/support/omero4">OMERO</a>
                                 </li>
                                 <li>
-                                    <a href="/site/support/bio-formats" accesskey="b" title="">Bio-Formats</a>
+                                    <a href="/site/support/bio-formats">Bio-Formats</a>
                                 </li>
                                 <li>
-                                    <a href="/site/support/ome-model" accesskey="f" title="">OME Model and Formats</a>
+                                    <a href="/site/support/ome-model">OME Model and Formats</a>
                                 </li>
                                 <li>
-                                    <a href="/site/support/partner" accesskey="p" title="">Partner Projects</a>
+                                    <a href="/site/support/partner">Partner Projects</a>
                                 </li>
                                 <li id="portaltab-ome5" class="plain">
-		                            <a href="/site/support" title="">OME 5</a>
-		                            <ul>
-		                                <li>
-		                                    <a href="/site/support/omero5" title="">OMERO 5</a>
-		                                </li>
-		                                <li>
-		                                    <a href="/site/support/bio-formats5" title="">Bio-Formats 5</a>
-		                                </li>
-		                            </ul>
+                                    <a href="/site/support">OME 5</a>
+                                    <ul>
+                                        <li>
+                                            <a href="/site/support/omero5">OMERO 5</a>
+                                        </li>
+                                        <li>
+                                            <a href="/site/support/bio-formats5">Bio-Formats 5</a>
+                                        </li>
+                                    </ul>
                                 </li>
                                 <li>
-                                    <a href="/site/support/legacy" accesskey="l" title="">Legacy</a>
+                                    <a href="/site/support/legacy">Legacy</a>
                                 </li>
                             </ul>
                         </li>
                         <li id="portaltab-community" class="plain">
-                            <a href="/site/community" accesskey="c" title="">Community</a>
+                            <a href="/site/community">Community</a>
                             <ul>
                                 <li>
-                                    <a href="/community" accesskey="f" title="">Forums</a>
+                                    <a href="/community">Forums</a>
                                 </li>
                                 <li>
-                                    <a href="/site/community/mailing-lists" accesskey="l" title="">Mailing Lists</a>
+                                    <a href="/site/community/mailing-lists">Mailing Lists</a>
                                 </li>
                                 <li>
-                                    <a href="/site/news" accesskey="n" title="">News and Events</a>
+                                    <a href="/site/news">News and Events</a>
                                 </li>
                                 <li>
-                                    <a href="/site/community/ome-stories" accesskey="o" title="">OME Stories</a>
+                                    <a href="/site/community/ome-stories">OME Stories</a>
                                 </li>
                                 <li>
-                                    <a href="/site/community/minutes" accesskey="m" title="">Minutes &amp; Meetings</a>
+                                    <a href="/site/community/minutes">Minutes &amp; Meetings</a>
                                 </li>
                                 <li>
-                                    <a href="/site/community/links" accesskey="u" title="">Developer Links</a>
+                                    <a href="/site/community/links">Developer Links</a>
                                 </li>
                                 <li>
-                                    <a href="/site/community/merchandise" accesskey="s" title="">Merchandise</a>
+                                    <a href="/site/community/merchandise">Merchandise</a>
                                 </li>
                                 <li>
-                                    <a href="http://qa.openmicroscopy.org.uk/" accesskey="q" title="">Quality Assurance Tools</a>
+                                    <a href="http://qa.openmicroscopy.org.uk/">Quality Assurance Tools</a>
                                 </li>
                                 <li>
-                                    <a href="/site/community/jobs" accesskey="j" title="">Job Openings with OME</a>
+                                    <a href="/site/community/jobs">Job Openings with OME</a>
                                 </li>
                             </ul>
                         </li>
                         <li id="portaltab-about" class="plain">
-                            <a href="/site/about/who-ome" accesskey="a" title="">About</a>
+                            <a href="/site/about/who-ome">About</a>
                             <ul>
                                 <li>
-                                    <a href="/site/about/who-ome" accesskey="o" title="">The OME Teams</a>
+                                    <a href="/site/about/who-ome">The OME Teams</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/contributers" accesskey="c" title="">Contributors</a>
+                                    <a href="/site/about/contributers">Contributors</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/partners" accesskey="p" title="">Commercial Partners</a>
+                                    <a href="/site/about/partners">Commercial Partners</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/publications" accesskey="u" title="">Publications</a>
+                                    <a href="/site/about/publications">Publications</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/press-reports" accesskey="r" title="">Press Reports</a>
+                                    <a href="/site/about/press-reports">Press Reports</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/roadmap" accesskey="r" title="">Roadmap</a>
+                                    <a href="/site/about/roadmap">Roadmap</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/project-history" accesskey="h" title="">History</a>
+                                    <a href="/site/about/project-history">History</a>
                                 </li>
                                 <li>
-                                    <a href="/site/about/licensing-attribution" accesskey="l" title="">Licensing &amp; Attribution</a>
+                                    <a href="/site/about/licensing-attribution">Licensing &amp; Attribution</a>
                                 </li>
                             </ul>
                         </li>
                         <li id="portaltab-about" class="plain">
-                            <a href="/site/support/faq" accesskey="f" title="">FAQ</a>
+                            <a href="/site/support/faq">FAQ</a>
                         </li>
                         <li class="invisibleHeightKeeper">&nbsp;
                         </li>


### PR DESCRIPTION
This removes the duplicate access keys. They have just been assigned in alphabetical order using both capitals and lowercase letters as there was too many. Before we had thought that the keys had to be unique on a submenu basis, but they have to be unique on a page basis.
