### PR TITLE
Adding contributing docs to website menu

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -77,6 +77,9 @@
                                     <a href="/site/support/ome-model">OME Model and Formats</a>
                                 </li>
                                 <li>
+                                    <a href="/site/support/contributing">Contributing to OME</a>
+                                </li>
+                                <li>
                                     <a href="/site/support/partner">Partner Projects</a>
                                 </li>
                                 <li id="portaltab-ome5" class="plain">


### PR DESCRIPTION
Contributing documentation is at http://www.openmicroscopy.org/site/support/contributing(-staging/) - once this PR is built, this section of the docs should be available from the top menu on all the staging docs (OMERO, BF and Model).

See https://trac.openmicroscopy.org.uk/ome/ticket/11186 for further details
