### PR TITLE
5 release menu changes

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -83,7 +83,7 @@
                                     <a href="http://help.openmicroscopy.org">User Help Website</a>
                                 </li>
                                 <li>
-                                    <a href="/site/support/legacy">Previous versions</a>
+                                    <a href="/site/support/previous">Previous versions</a>
                                 </li>
                             </ul>
                         </li>


### PR DESCRIPTION
This fixes the website menus for the 5 release
- Remove OME 5 under /products/
- Make default 'OMERO' and 'BF' docs menu items point at 5
- Delete OME 5 docs menu
- Rename 'legacy' docs as 'previous versions'
