### PR TITLE
Override sphinxdoc.css to put sidebar on the left

### DIFF
--- a/static/plonematch.css_t
+++ b/static/plonematch.css_t
@@ -1,5 +1,15 @@
 @import url("sphinxdoc.css");
 
+div.sphinxsidebar {
+    float: left;
+}
+div.bodywrapper {
+    margin: 0 0 0 240px;
+}
+div.sphinxsidebarwrapper {
+    padding: 10px 0px 0px 10px;
+}
+
 @media screen {
 /* The global section tabs. */
 #portal-globalnav {


### PR DESCRIPTION
Following @pwalczysko suggestions, this PR modifies the generic sphinx_theme
to move the sidebar on the left-side of the window.
