### PR TITLE
Keep the same size for the option name and its target

### DIFF
--- a/static/plonematch.css_t
+++ b/static/plonematch.css_t
@@ -193,6 +193,10 @@ a.internal > em {
     font-style: normal;
 }
 
+tt.descname {
+    font-size: 1em;
+}
+
 /* Options for sortable tables */
 table.sortable thead {
 }


### PR DESCRIPTION
See https://github.com/openmicroscopy/ome-documentation/pull/875#issuecomment-49146367. This commit overrides the following settings from the basic.css_t template:

```
tt.descname {
...
    font-size: 1.2em;
}
```
