### PR TITLE
Fix overflow of code highlighting.

### DIFF
--- a/static/plonematch.css_t
+++ b/static/plonematch.css_t
@@ -11,15 +11,11 @@ div.sphinxsidebarwrapper {
     padding: 10px 0px 0px 10px;
 }
 
-div.admonition, div.warning {
-    display: block;
-}
-
+div.topic,
+div.admonition,
+div.warning,
 div.highlight-python {
     display: block;
-}
-
-div.topic, div.highlight-python {
     overflow: auto;
 }
 


### PR DESCRIPTION
This PR should fix the issue discovered by @joshmoore (https://github.com/openmicroscopy/sphinx_theme/pull/13#issuecomment-49158420).

To test, see if all code and command boxes look OK and that highlighting doesn't overflow under the sidebar.
