### PR TITLE
Simplify CSS for overflow.

### DIFF
--- a/static/plonematch.css_t
+++ b/static/plonematch.css_t
@@ -11,11 +11,8 @@ div.sphinxsidebarwrapper {
     padding: 10px 0px 0px 10px;
 }
 
-div.topic,
-div.admonition,
-div.warning,
-div.highlight-python {
-    display: block;
+/* Fix for narrow browser windows */
+div.related, div.body > div {
     overflow: auto;
 }
 


### PR DESCRIPTION
This PR is a final take on the overflow of the left-adjusted sidebar. It should allow nice rendering of all pages in a narrow browser window. Fixes bullet-point issue noticed by @ximenesuk (https://github.com/openmicroscopy/sphinx_theme/pull/15#issuecomment-49849174). 

The final thing to fix after this get merged is the LDAP doc page (shorten the paragraph headings).
