### PR TITLE
Fix table margin.

### DIFF
--- a/static/plonematch.css_t
+++ b/static/plonematch.css_t
@@ -16,6 +16,11 @@ div.related, div.body > div {
     overflow: auto;
 }
 
+/* Fix for negative table margin */
+table.docutils {
+    margin: 0em;
+}
+
 @media screen {
 /* The global section tabs. */
 #portal-globalnav {


### PR DESCRIPTION
This PR should fix the table layout (tables' margin was set to -0.5em which caused them to be overflowed by the sidebar. See screenshot).
![screen shot 2014-08-11 at 11 46 11](https://cloud.githubusercontent.com/assets/1692189/3874664/bd133036-2144-11e4-8921-7b00ee40e5cf.png)
